### PR TITLE
fix: use v0 of google-github-actions/run-gemini-cli instead of v1

### DIFF
--- a/.github/workflows/gemini.yml
+++ b/.github/workflows/gemini.yml
@@ -6,7 +6,7 @@ jobs:
   triage:
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/run-gemini-cli@v1
+      - uses: google-github-actions/run-gemini-cli@v0
         with:
           gemini_api_key: ${{ secrets.GEMINI_API_KEY }}
           prompt: "このIssueをトリアージし、適切なラベルを付けてください。"


### PR DESCRIPTION
## 概要
GitHub Actions ワークフローで使用している `google-github-actions/run-gemini-cli` のバージョンが誤って `v1` になっていたため、`v0` に修正しました。

## 変更内容
- ワークフロー `.github/workflows/triage.yml` において、`uses: google-github-actions/run-gemini-cli@v1` を `@v0` に変更

## 背景
公式ドキュメントでは `v0` のみが提供されており、`v1` は存在しないため、ワークフロー実行時にエラーとなる可能性があります。

## テスト
- 実際の GitHub Actions 実行環境でエラーが解消される見込みです

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Chores
  * Triage ジョブで使用する Gemini CLI アクションのバージョンを更新。
  * 既存の入力値や処理の流れに変更はなく、ユーザー向けの機能や表示への影響はありません。ビルドやデプロイの手順は従来どおりです。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->